### PR TITLE
Conversion script fix for maya2018

### DIFF
--- a/SceneConversionScripts/convertAI2RPR.py
+++ b/SceneConversionScripts/convertAI2RPR.py
@@ -11,16 +11,15 @@
 
 # Arnold to RadeonProRender Converter
 
-import maya.mel as mel
-import maya.cmds as cmds
 import time
 import os
 import math
 import traceback
 
-from maya.plugin.evaluator.cache_preferences import CachePreferenceEnabled
+import maya.mel as mel
+import maya.cmds as cmds
 
-ARNOLD2RPR_CONVERTER_VERSION = "2.9.2"
+ARNOLD2RPR_CONVERTER_VERSION = "2.9.3"
 
 # log functions
 
@@ -3350,6 +3349,7 @@ def convertScene():
 	# Disable caching
 	maya_version = cmds.about(apiVersion=True)
 	if maya_version > 20190200:
+		from maya.plugin.evaluator.cache_preferences import CachePreferenceEnabled
 		cache_preference_enabled = CachePreferenceEnabled().get_value()
 		if cache_preference_enabled:
 			CachePreferenceEnabled().set_value(False)

--- a/SceneConversionScripts/convertRS2RPR.py
+++ b/SceneConversionScripts/convertRS2RPR.py
@@ -18,9 +18,8 @@ import traceback
 
 import maya.mel as mel
 import maya.cmds as cmds
-from maya.plugin.evaluator.cache_preferences import CachePreferenceEnabled
 
-RS2RPR_CONVERTER_VERSION = "2.4.1"
+RS2RPR_CONVERTER_VERSION = "2.5.2"
 
 # log functions
 
@@ -3388,6 +3387,7 @@ def convertScene():
 	# Disable caching
 	maya_version = cmds.about(apiVersion=True)
 	if maya_version > 20190200:
+		from maya.plugin.evaluator.cache_preferences import CachePreferenceEnabled
 		cache_preference_enabled = CachePreferenceEnabled().get_value()
 		if cache_preference_enabled:
 			CachePreferenceEnabled().set_value(False)
@@ -3421,7 +3421,7 @@ def convertScene():
 			exit("RadeonProRender plugin is not installed")
 
 	# redshift engine set before conversion
-	setProperty("defaultRenderGlobals","currentRenderer", "redshift")
+	setProperty("defaultRenderGlobals", "currentRenderer", "redshift")
 
 	# Convert RedshiftEnvironment
 	env = cmds.ls(type="RedshiftEnvironment")


### PR DESCRIPTION
PURPOSE:
Checking on "timeline cache" option in Maya 2018 leads to script execution error

EFFECT OF CHANGES:
We don't perfrom such check in case of Maya 2018 (as it has no such option)