### PR TITLE
Add interface flag to force CPU image filter context usage

### DIFF
--- a/src/ImageFilter/ImageFilter.cpp
+++ b/src/ImageFilter/ImageFilter.cpp
@@ -56,7 +56,7 @@ static rpr_int GpuDeviceIdUsed(rpr_creation_flags contextFlags)
 	return -1;
 }
 
-ImageFilter::ImageFilter(const rpr_context rprContext, std::uint32_t width, std::uint32_t height, const std::string& modelsPath) :
+ImageFilter::ImageFilter(const rpr_context rprContext, std::uint32_t width, std::uint32_t height, const std::string& modelsPath, bool forceCPUContext /*= false*/) :
 	mWidth(width),
 	mHeight(height),
 	mModelsPath(modelsPath)
@@ -72,7 +72,7 @@ ImageFilter::ImageFilter(const rpr_context rprContext, std::uint32_t width, std:
 	{
 		mRifContext.reset( new RifContextGPUMetal(rprContext) );
 	}
-	else if (HasGpuContext(contextFlags))
+	else if (HasGpuContext(contextFlags) && !forceCPUContext)
 	{
 		mRifContext.reset(new RifContextGPU(rprContext));
 	}

--- a/src/ImageFilter/ImageFilter.h
+++ b/src/ImageFilter/ImageFilter.h
@@ -91,7 +91,7 @@ class ImageFilter final
 
 public:
 	explicit ImageFilter(const rpr_context rprContext, std::uint32_t width, std::uint32_t height,
-		const std::string& modelsPath = std::string());
+		const std::string& modelsPath = std::string(), bool forceCPUContext = false);
 	~ImageFilter();
 
 	void CreateFilter(RifFilterType rifFilteType, bool useOpenImageDenoise = false);


### PR DESCRIPTION
In RPR 20 Frame Buffers are always on RAM, while in old RPR they can be in GPU memory.

Thus a way to give information about whether GPUContext should be used or not is needed.