### PR TITLE
Fix alembic UV loading bug

### DIFF
--- a/src/Alembic/AlembicWrapper.cpp
+++ b/src/Alembic/AlembicWrapper.cpp
@@ -557,7 +557,7 @@ namespace RPRAlembicWrapper
 		if (uv)
 		{
 			polymeshObject->UV.resize(uv->rowCount());
-			for (int i = 0; i < polymeshObject->N.size(); ++i)
+			for (int i = 0; i < polymeshObject->UV.size(); ++i)
 			{
 				float *xy = (float *)&polymeshObject->UV[i];
 				uv->get(i, xy);


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2349

PURPOSE: On some shapes we were not reading UV data correctly

TECHNICAL DETAILS: Basically there was a typing mistake :(  (it used to work in most cases because size of normal and uv arrays were identical)