### PR TITLE
Arnold converter 2.9.7

### DIFF
--- a/SceneConversionScripts/convertAI2RPR.py
+++ b/SceneConversionScripts/convertAI2RPR.py
@@ -1506,14 +1506,28 @@ def convertaiFacingRatio(ai, source):
 	if cmds.objExists(ai + "_rpr"):
 		rpr = ai + "_rpr"
 	else:
-		rpr = cmds.shadingNode("RPRLookup", asUtility=True)
-		rpr = cmds.rename(rpr, ai + "_rpr")
-			
+		rpr = cmds.shadingNode("RPRArithmetic", asUtility=True)
+		rpr = cmds.rename(rpr, ai + "_abs_rpr")
+
 		# Logging to file
 		start_log(ai, rpr)
 
-		# Fields conversion
-		setProperty(rpr, "type", 3)
+		setProperty(rpr, "operation", 25)
+
+		dot = cmds.shadingNode("RPRArithmetic", asUtility=True)
+		dot = cmds.rename(dot, ai + "_dot_rpr")
+		setProperty(dot, "operation", 11)
+		connectProperty(dot, "out", rpr, "inputA")
+
+		incident = cmds.shadingNode("RPRLookup", asUtility=True)
+		incident = cmds.rename(incident, ai + "_incident_rpr")
+		setProperty(incident, "type", 3)
+		connectProperty(incident, "out", dot, "inputA")
+
+		normal = cmds.shadingNode("RPRLookup", asUtility=True)
+		normal = cmds.rename(normal, ai + "_normal_rpr")
+		setProperty(normal, "type", 1)
+		connectProperty(normal, "out", dot, "inputB")
 
 		# Logging to file
 		end_log(ai)
@@ -2293,8 +2307,7 @@ def convertaiStandardSurface(aiMaterial, source):
 		copyProperty(rprMaterial, aiMaterial, "reflectAnisotropyRotation", "specularRotation")
 		copyProperty(rprMaterial, aiMaterial, "reflectIOR", "specularIOR")
 
-		metalness = getProperty(aiMaterial, "metalness")
-		if metalness:
+		if not mapDoesNotExist(aiMaterial, "metalness") or getProperty(aiMaterial, "metalness"):
 			setProperty(rprMaterial, "reflections", 1)
 			setProperty(rprMaterial, "diffuse", 1)
 			setProperty(rprMaterial, "reflectMetalMaterial", 1)

--- a/SceneConversionScripts/convertAI2RPR.py
+++ b/SceneConversionScripts/convertAI2RPR.py
@@ -2250,6 +2250,7 @@ def convertaiStandardSurface(aiMaterial, source):
 		defaultEnable(rprMaterial, aiMaterial, "sssEnable", "subsurface")
 		defaultEnable(rprMaterial, aiMaterial, "emissive", "emission")
 		defaultEnable(rprMaterial, aiMaterial, "clearCoat", "coat")
+		defaultEnable(rprMaterial, aiMaterial, "sheenEnabled", "sheen")
 
 		# Logging to file
 		start_log(aiMaterial, rprMaterial)
@@ -2284,7 +2285,7 @@ def convertaiStandardSurface(aiMaterial, source):
 
 		copyProperty(rprMaterial, aiMaterial, "volumeScatter", "subsurfaceColor")
 		copyProperty(rprMaterial, aiMaterial, "sssWeight", "subsurface")
-		copyProperty(rprMaterial, aiMaterial, "backscatteringWeight", "subsurface")
+		setProperty(rprMaterial, "backscatteringWeight", 0.05)
 		if mapDoesNotExist(aiMaterial, "subsurfaceRadius"):
 			setProperty(rprMaterial, "subsurfaceRadius", getProperty(aiMaterial, "subsurfaceRadius"))
 		else:
@@ -2296,14 +2297,16 @@ def convertaiStandardSurface(aiMaterial, source):
 			setProperty(rprMaterial, "diffuseWeight", 1)
 			setProperty(rprMaterial, "separateBackscatterColor", 0)
 			setProperty(rprMaterial, "multipleScattering", 0)
-			setProperty(rprMaterial, "backscatteringWeight", 0.75)
-
+		
 			subsurfaceType = getProperty(aiMaterial, "subsurfaceType")
 			if subsurfaceType == 0: # diffusion type
 				copyProperty(rprMaterial, aiMaterial, "diffuseColor", "subsurfaceColor")
-				setProperty(rprMaterial, "backscatteringWeight", 0.125)
 			elif subsurfaceType == 1: # randomwalk
-				setProperty(rprMaterial, "backscatteringWeight", 0.05)
+				pass
+
+		copyProperty(rprMaterial, aiMaterial, "sheenWeight", "sheen")
+		copyProperty(rprMaterial, aiMaterial, "sheenColor", "sheenColor")
+		invertValue(rprMaterial, aiMaterial, "sheenTint", "sheenRoughness")
 			
 		copyProperty(rprMaterial, aiMaterial, "coatColor", "coatColor")
 		copyProperty(rprMaterial, aiMaterial, "coatTransmissionColor", "coatColor")

--- a/SceneConversionScripts/convertAI2RPR.py
+++ b/SceneConversionScripts/convertAI2RPR.py
@@ -19,7 +19,7 @@ import traceback
 import maya.mel as mel
 import maya.cmds as cmds
 
-ARNOLD2RPR_CONVERTER_VERSION = "2.9.3"
+ARNOLD2RPR_CONVERTER_VERSION = "2.9.7"
 
 # log functions
 

--- a/SceneConversionScripts/convertAI2RPR.py
+++ b/SceneConversionScripts/convertAI2RPR.py
@@ -1380,6 +1380,32 @@ def convertPreMultiply(ai, source):
 	return rpr
 
 
+def convertaiRange(ai, source):
+
+	if cmds.objExists(ai + "_rpr"):
+		rpr = ai + "_rpr"
+	else:
+		rpr = cmds.shadingNode("remapColor", asUtility=True)
+		rpr = cmds.rename(rpr, ai + "_rpr")
+
+		# Logging to file
+		start_log(ai, rpr)
+
+		# Fields conversion
+		copyProperty(rpr, ai, "color", "input")
+
+		copyProperty(rpr, ai, "inputMin", "inputMin")
+		copyProperty(rpr, ai, "inputMax", "inputMax")
+		copyProperty(rpr, ai, "outputMin", "outputMin")
+		copyProperty(rpr, ai, "outputMax", "outputMax")
+
+		# Logging to file
+		end_log(ai)
+
+	rpr += "." + source
+	return rpr
+
+
 def convertVectorProduct(ai, source):
 
 	operation = getProperty(ai, "operation")
@@ -2285,7 +2311,7 @@ def convertaiStandardSurface(aiMaterial, source):
 
 		copyProperty(rprMaterial, aiMaterial, "volumeScatter", "subsurfaceColor")
 		copyProperty(rprMaterial, aiMaterial, "sssWeight", "subsurface")
-		setProperty(rprMaterial, "backscatteringWeight", 0.05)
+		copyProperty(rprMaterial, aiMaterial, "backscatteringWeight", "subsurface")
 		if mapDoesNotExist(aiMaterial, "subsurfaceRadius"):
 			setProperty(rprMaterial, "subsurfaceRadius", getProperty(aiMaterial, "subsurfaceRadius"))
 		else:
@@ -2297,12 +2323,16 @@ def convertaiStandardSurface(aiMaterial, source):
 			setProperty(rprMaterial, "diffuseWeight", 1)
 			setProperty(rprMaterial, "separateBackscatterColor", 0)
 			setProperty(rprMaterial, "multipleScattering", 0)
+			setProperty(rprMaterial, "backscatteringWeight", 0.75)
 		
 			subsurfaceType = getProperty(aiMaterial, "subsurfaceType")
 			if subsurfaceType == 0: # diffusion type
 				copyProperty(rprMaterial, aiMaterial, "diffuseColor", "subsurfaceColor")
+				setProperty(rprMaterial, "backscatteringWeight", 0.125)
 			elif subsurfaceType == 1: # randomwalk
-				pass
+				setProperty(rprMaterial, "backscatteringWeight", 0.05)
+			elif subsurfaceType == 2: # randomwalk v2
+				setProperty(rprMaterial, "backscatteringWeight", 0.1)
 
 		copyProperty(rprMaterial, aiMaterial, "sheenWeight", "sheen")
 		copyProperty(rprMaterial, aiMaterial, "sheenColor", "sheenColor")
@@ -3225,7 +3255,8 @@ def convertMaterial(aiMaterial, source):
 		"aiTriplanar": convertaiTriplanar,
 		"aiUvTransform": convertaiUvTransform,
 		"aiLength": convertaiLength,
-		"aiExp": convertaiExp
+		"aiExp": convertaiExp,
+		"aiRange": convertaiRange
 	}
 
 	if ai_type in conversion_func:
@@ -3292,7 +3323,7 @@ def cleanScene():
 
 	listObjects = cmds.ls(l=True)
 	for obj in listObjects:
-		if isArnoldType(object):
+		if isArnoldType(obj):
 			try:
 				cmds.delete(obj)
 			except:


### PR DESCRIPTION
PURPSE:
Arnold converter is out of date

EFFECT OF CHANGES:
Update Arnold converter to 2.9.7:

 - aiFacingRatio conversion changed
 - Add aiRange to remapColor conversion. Fix bug with deleting utilities
 - Added converting changes to backscatteringWeight in aiStandardSurface